### PR TITLE
[Translations] Add interface ITranslation for all Translated Resources

### DIFF
--- a/samples/StarWars.Tests/SchemaTest.cs
+++ b/samples/StarWars.Tests/SchemaTest.cs
@@ -26,6 +26,5 @@ namespace StarWars.Tests
             //Assert
             schema.ToString().MatchSnapshot("schema");
         }
-
     }
 }

--- a/samples/StarWars.Tests/__snapshots__/schema.snap
+++ b/samples/StarWars.Tests/__snapshots__/schema.snap
@@ -18,6 +18,10 @@ interface Character {
   name: String!
 }
 
+interface ITranslation {
+  label: String!
+}
+
 "A connection to a list of items."
 type CharactersConnection {
   "A list of edges."
@@ -172,17 +176,17 @@ type Subscription {
   onReview("The episode to which you want to subscribe to." episode: Episode!): Review!
 }
 
-type TranslatedResourceOfEpisode {
+type TranslatedResourceOfEpisode implements ITranslation {
   key: Episode!
   label: String!
 }
 
-type TranslatedResourceOfHairColor {
+type TranslatedResourceOfHairColor implements ITranslation {
   key: HairColor!
   label: String!
 }
 
-type TranslatedResourceOfMaritalStatus {
+type TranslatedResourceOfMaritalStatus implements ITranslation {
   key: MaritalStatus!
   label: String!
 }

--- a/src/HotChocolate.Extensions.Translation.Tests/Configuration/RequestExecutorBuilderExtensionsTests.cs
+++ b/src/HotChocolate.Extensions.Translation.Tests/Configuration/RequestExecutorBuilderExtensionsTests.cs
@@ -1,0 +1,67 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using HotChocolate.Execution;
+using HotChocolate.Execution.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Snapshooter.Xunit;
+using Xunit;
+
+namespace HotChocolate.Extensions.Translation.Tests.Configuration
+{
+    public class RequestExecutorBuilderExtensionsTests
+    {
+        public class Query
+        {
+            public string Foo { get; } = "bar";
+            public DummyEnum Baz { get; } = DummyEnum.Qux;
+        }
+
+        public enum DummyEnum
+        {
+            Qux
+        }
+
+        [Fact]
+        public async Task AddTranslation_WithTranslatedEnum_ShouldAddTheTypeForTheTranslatedEnum()
+        {
+            //Arrange
+            var services = new ServiceCollection();
+            IRequestExecutorBuilder builder = services
+                .AddGraphQLServer()
+                .AddQueryType<Query>(d =>
+                {
+                    d.Field(q => q.Baz).Translate<DummyEnum>("translation_path");
+                });
+
+            //Act
+            builder = builder
+                .AddTranslation(c => c
+                    .AddTranslatableType<DummyEnum>()
+                );
+
+            //Assert
+            ISchema schema = await builder.BuildSchemaAsync();
+            schema.ToString().Should().MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task AddTranslation_WithCustomNameForInterface_ShouldAddTheInterfaceWithTheCorrectName()
+        {
+            //Arrange
+            var services = new ServiceCollection();
+            IRequestExecutorBuilder builder = services
+                .AddGraphQLServer()
+                .AddQueryType<Query>();
+
+            //Act
+            builder = builder
+                .AddTranslation(c => c
+                    .SetTranslationInterfaceName("MyTranslationInterfaceType")
+                );
+
+            //Assert
+            ISchema schema = await builder.BuildSchemaAsync();
+            schema.ToString().Should().MatchSnapshot();
+        }
+    }
+}

--- a/src/HotChocolate.Extensions.Translation.Tests/Configuration/__snapshots__/RequestExecutorBuilderExtensionsTests.AddTranslation_WithCustomNameForInterface_ShouldAddTheInterfaceWithTheCorrectName.snap
+++ b/src/HotChocolate.Extensions.Translation.Tests/Configuration/__snapshots__/RequestExecutorBuilderExtensionsTests.AddTranslation_WithCustomNameForInterface_ShouldAddTheInterfaceWithTheCorrectName.snap
@@ -1,0 +1,21 @@
+﻿schema {
+  query: Query
+}
+
+interface MyTranslationInterfaceType {
+  label: String!
+}
+
+type Query {
+  foo: String!
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! "Streamed when true." if: Boolean) on FIELD
+
+directive @translatable(resourceKeyPrefix: String! toCodeLabelItem: Boolean!) on FIELD_DEFINITION
+
+directive @translate(language: String) on FIELD | FIELD_DEFINITION

--- a/src/HotChocolate.Extensions.Translation.Tests/Configuration/__snapshots__/RequestExecutorBuilderExtensionsTests.AddTranslation_WithTranslatedEnum_ShouldAddTheTypeForTheTranslatedEnum.snap
+++ b/src/HotChocolate.Extensions.Translation.Tests/Configuration/__snapshots__/RequestExecutorBuilderExtensionsTests.AddTranslation_WithTranslatedEnum_ShouldAddTheTypeForTheTranslatedEnum.snap
@@ -1,0 +1,33 @@
+﻿schema {
+  query: Query
+}
+
+interface ITranslation {
+  label: String!
+}
+
+type Query {
+  baz: TranslatedResourceOfDummyEnum! @translatable(resourceKeyPrefix: "translation_path", toCodeLabelItem: true) @translateDummyEnum
+  foo: String!
+}
+
+type TranslatedResourceOfDummyEnum implements ITranslation {
+  key: DummyEnum!
+  label: String!
+}
+
+enum DummyEnum {
+  QUX
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! "Streamed when true." if: Boolean) on FIELD
+
+directive @translatable(resourceKeyPrefix: String! toCodeLabelItem: Boolean!) on FIELD_DEFINITION
+
+directive @translate(language: String) on FIELD | FIELD_DEFINITION
+
+directive @translateDummyEnum(language: String) on FIELD | FIELD_DEFINITION

--- a/src/HotChocolate.Extensions.Translation/Configuration/RequestExecutorBuilderExtensions.cs
+++ b/src/HotChocolate.Extensions.Translation/Configuration/RequestExecutorBuilderExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using HotChocolate.Execution.Configuration;
 using HotChocolate.Extensions.Translation;
-using HotChocolate.Types;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/HotChocolate.Extensions.Translation/Configuration/RequestExecutorBuilderExtensions.cs
+++ b/src/HotChocolate.Extensions.Translation/Configuration/RequestExecutorBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using HotChocolate.Execution.Configuration;
 using HotChocolate.Extensions.Translation;
+using HotChocolate.Types;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -16,15 +17,21 @@ namespace Microsoft.Extensions.DependencyInjection
             this IRequestExecutorBuilder builder,
             Action<TranslationBuilder>? configure)
         {
-            IRequestExecutorBuilder b = builder
-                .AddDirectiveType<TranslateDirectiveType>()
-                .AddDirectiveType<TranslatableDirectiveType>();
+            var translateDirective = new TranslateDirectiveType();
+            var translatableDirective = new TranslatableDirectiveType();
+            var translationInterfaceType = new TranslationInterfaceType();
 
-            if(configure != null)
+            if (configure != null)
             {
-                var translationBuilder = new TranslationBuilder(b);
+                var translationBuilder = new TranslationBuilder(
+                    builder, translationInterfaceType);
                 configure(translationBuilder);
             }
+
+            IRequestExecutorBuilder b = builder
+                .AddDirectiveType(translateDirective)
+                .AddDirectiveType(translatableDirective)
+                .AddType(translationInterfaceType);
 
             return b;
         }

--- a/src/HotChocolate.Extensions.Translation/Configuration/TranslationBuilder.cs
+++ b/src/HotChocolate.Extensions.Translation/Configuration/TranslationBuilder.cs
@@ -6,16 +6,26 @@ namespace Microsoft.Extensions.DependencyInjection
     public class TranslationBuilder
     {
         private readonly IRequestExecutorBuilder _requestExecutorBuilder;
+        private readonly TranslationInterfaceType _translationInterfaceType;
 
-        internal TranslationBuilder(IRequestExecutorBuilder requestExecutorBuilder)
+        public TranslationBuilder(
+            IRequestExecutorBuilder requestExecutorBuilder,
+            TranslationInterfaceType translationInterfaceType)
         {
             _requestExecutorBuilder = requestExecutorBuilder;
+            _translationInterfaceType = translationInterfaceType;
         }
 
         public TranslationBuilder AddTranslatableType<T>()
         {
             _requestExecutorBuilder.AddDirectiveType<TranslateDirectiveType<T>>();
 
+            return this;
+        }
+
+        public TranslationBuilder SetTranslationInterfaceName(string name)
+        {
+            _translationInterfaceType.InterfaceName = name;
             return this;
         }
     }

--- a/src/HotChocolate.Extensions.Translation/ITranslation.cs
+++ b/src/HotChocolate.Extensions.Translation/ITranslation.cs
@@ -1,0 +1,7 @@
+namespace HotChocolate.Extensions.Translation
+{
+    public interface ITranslation
+    {
+        public string Label { get; }
+    }
+}

--- a/src/HotChocolate.Extensions.Translation/TranslatedResource.cs
+++ b/src/HotChocolate.Extensions.Translation/TranslatedResource.cs
@@ -1,6 +1,6 @@
 namespace HotChocolate.Extensions.Translation
 {
-    public class TranslatedResource<T>
+    public class TranslatedResource<T>: ITranslation
     {
         public TranslatedResource(T key, string label)
         {

--- a/src/HotChocolate.Extensions.Translation/TranslationInterfaceType.cs
+++ b/src/HotChocolate.Extensions.Translation/TranslationInterfaceType.cs
@@ -1,0 +1,18 @@
+using HotChocolate.Types;
+
+namespace HotChocolate.Extensions.Translation
+{
+    public class TranslationInterfaceType: InterfaceType<ITranslation>
+    {
+        internal string? InterfaceName { get; set; }
+
+        protected override void Configure(
+            IInterfaceTypeDescriptor<ITranslation> descriptor)
+        {
+            if(InterfaceName != null)
+            {
+                descriptor.Name(InterfaceName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Before, the generated TranslatedResource Types had nothing in common except that they all have a field label of type String.
They now implement an interface ITranslation:

```
interface ITranslation {
   label: String!
}

type TranslatedResourceOfDummyEnum implements ITranslation {
  key: DummyEnum!
  label: String!
}

enum DummyEnum {
  QUX
}
```

Addresses enhancement #10 
