### PR TITLE
Tracking: TagTracking with Attribute + Made @tracked directive repeatable

### DIFF
--- a/samples/StarWars.Tests/__snapshots__/schema.snap
+++ b/samples/StarWars.Tests/__snapshots__/schema.snap
@@ -104,7 +104,7 @@ type Human implements Character {
 "The mutations related to reviews."
 type Mutation {
   "Creates a review for a given Star Wars episode."
-  createReview(input: CreateReviewInput!): CreateReviewPayload! @tracked
+  createReview(input: CreateReviewInput!): CreateReviewPayload! @tracked @tracked
 }
 
 "Information about pagination in a connection."
@@ -376,7 +376,7 @@ directive @specifiedBy("The specifiedBy URL points to a human-readable specifica
 "The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
 directive @stream("Streamed when true." if: Boolean "The initial elements that shall be send down to the consumer." initialCount: Int! "If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String) on FIELD
 
-directive @tracked on FIELD_DEFINITION
+directive @tracked repeatable on FIELD_DEFINITION
 
 directive @translatable(resourceKeyPrefix: String! toCodeLabelItem: Boolean!) on FIELD_DEFINITION
 

--- a/samples/StarWars/RequestExecutorBuilderExtensions.cs
+++ b/samples/StarWars/RequestExecutorBuilderExtensions.cs
@@ -44,7 +44,6 @@ namespace StarWars
                 /* HotChocolate.Extensions.Tracking Pipeline */
                 .AddTrackingPipeline(builder => builder
                     .AddExporter<KpiTrackingExporter>()
-                       // .AddSupportedType<ReviewTrackingEntry>()
                     .AddDeprecatedFieldsTracking<DeprecatedFieldsTracingExporter>())
 
                 .ModifyOptions(o => o.SortFieldsByName = true);

--- a/samples/StarWars/Reviews/ReviewMutations.cs
+++ b/samples/StarWars/Reviews/ReviewMutations.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using HotChocolate;
 using HotChocolate.Extensions.Tracking;
+using HotChocolate.Extensions.Tracking.TagTracking;
 using HotChocolate.Subscriptions;
 using HotChocolate.Types;
 using StarWars.Repositories;
@@ -17,7 +18,8 @@ namespace StarWars.Reviews
         /// <summary>
         /// Creates a review for a given Star Wars episode.
         /// </summary>
-        [Track<ReviewTrackingEntryFactory>]
+        [Track<ReviewTrackingEntryFactory>] // tracking with a custom message
+        [Track("NewReview")] // simple tracking with a simple tag+date message
         public async Task<CreateReviewPayload> CreateReview(
             CreateReviewInput input,
             [Service]IReviewRepository repository,

--- a/src/HotChocolate.Extensions.Tracking.MassTransit.Tests/Default/IntegrationTests.cs
+++ b/src/HotChocolate.Extensions.Tracking.MassTransit.Tests/Default/IntegrationTests.cs
@@ -7,7 +7,7 @@ using FluentAssertions;
 using HotChocolate;
 using HotChocolate.Execution;
 using HotChocolate.Extensions.Tracking;
-using HotChocolate.Extensions.Tracking.Default;
+using HotChocolate.Extensions.Tracking.TagTracking;
 using HotChocolate.Types;
 using MassTransit;
 using Microsoft.AspNetCore.Http;

--- a/src/HotChocolate.Extensions.Tracking/TagTracking/ObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate.Extensions.Tracking/TagTracking/ObjectFieldDescriptorExtensions.cs
@@ -1,6 +1,6 @@
 using HotChocolate.Types;
 
-namespace HotChocolate.Extensions.Tracking.Default;
+namespace HotChocolate.Extensions.Tracking.TagTracking;
 
 public static class ObjectFieldDescriptorExtensions
 {

--- a/src/HotChocolate.Extensions.Tracking/TagTracking/TagTrackingEntry.cs
+++ b/src/HotChocolate.Extensions.Tracking/TagTracking/TagTrackingEntry.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace HotChocolate.Extensions.Tracking.Default;
+namespace HotChocolate.Extensions.Tracking.TagTracking;
 
 public class TagTrackingEntry : ITrackingEntry
 {

--- a/src/HotChocolate.Extensions.Tracking/TagTracking/TagTrackingEntryFactory.cs
+++ b/src/HotChocolate.Extensions.Tracking/TagTracking/TagTrackingEntryFactory.cs
@@ -2,7 +2,7 @@ using System;
 using HotChocolate.Resolvers;
 using Microsoft.AspNetCore.Http;
 
-namespace HotChocolate.Extensions.Tracking.Default;
+namespace HotChocolate.Extensions.Tracking.TagTracking;
 
 public sealed class TagTrackingEntryFactory : ITrackingEntryFactory
 {

--- a/src/HotChocolate.Extensions.Tracking/TagTracking/TrackAttribute.cs
+++ b/src/HotChocolate.Extensions.Tracking/TagTracking/TrackAttribute.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Reflection;
+using HotChocolate.Types;
+using HotChocolate.Types.Descriptors;
+
+namespace HotChocolate.Extensions.Tracking.TagTracking
+{
+    [AttributeUsage(
+        AttributeTargets.Property | AttributeTargets.Method,
+        Inherited = true,
+        AllowMultiple = false)]
+    public class TrackAttribute: DescriptorAttribute
+    {
+        public TrackAttribute(string tagName)
+        {
+            TagName = tagName;
+        }
+
+        public string TagName { get; set; }
+
+        protected override void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element)
+        {
+            if (descriptor is IObjectFieldDescriptor d)
+            {
+                d.Track(TagName);
+            }
+        }
+    }
+}

--- a/src/HotChocolate.Extensions.Tracking/TrackedDirectiveType.cs
+++ b/src/HotChocolate.Extensions.Tracking/TrackedDirectiveType.cs
@@ -19,6 +19,7 @@ public sealed class TrackedDirectiveType : DirectiveType<TrackedDirective>
         descriptor.Name(DirectiveName);
         descriptor.Location(DirectiveLocation.FieldDefinition);
         descriptor.BindArgumentsExplicitly();
+        descriptor.Repeatable();
 
         descriptor.Use(next => context => Track(next, context));
     }


### PR DESCRIPTION
Tracking: 

- basic Tag Tracking can now be done with an attribute:
   ```C#
   public class Query
   {
        [Track("FooInvoked")]
        public string Foo => "bar";
   }
   ```
- the tracked directive is now repeatable (enables adding several trackers on a single graphQL Field)
- Moved `HotChocolate.Extensions.Tracking.Default` to `HotChocolate.Extensions.Tracking.TagTracking`


