### PR TITLE
Made tracking directive internal

### DIFF
--- a/src/HotChocolate.Extensions.Tracking/TrackedDirectiveType.cs
+++ b/src/HotChocolate.Extensions.Tracking/TrackedDirectiveType.cs
@@ -20,6 +20,7 @@ public sealed class TrackedDirectiveType : DirectiveType<TrackedDirective>
         descriptor.Location(DirectiveLocation.FieldDefinition);
         descriptor.BindArgumentsExplicitly();
         descriptor.Repeatable();
+        descriptor.Internal();
 
         descriptor.Use(next => context => Track(next, context));
     }


### PR DESCRIPTION
Made Tracking directive internal in order to avoid conflicts with similar directives in Stitching Apis. 
