### PR TITLE
Set default interface name

### DIFF
--- a/src/HotChocolate.Extensions.Translation.Tests/Configuration/__snapshots__/RequestExecutorBuilderExtensionsTests.AddTranslation_WithTranslatedEnum_ShouldAddTheTypeForTheTranslatedEnum.snap
+++ b/src/HotChocolate.Extensions.Translation.Tests/Configuration/__snapshots__/RequestExecutorBuilderExtensionsTests.AddTranslation_WithTranslatedEnum_ShouldAddTheTypeForTheTranslatedEnum.snap
@@ -2,7 +2,7 @@
   query: Query
 }
 
-interface ITranslation {
+interface Translation {
   label: String!
 }
 
@@ -11,7 +11,7 @@ type Query {
   foo: String!
 }
 
-type TranslatedResourceOfDummyEnum implements ITranslation {
+type TranslatedResourceOfDummyEnum implements Translation {
   key: DummyEnum!
   label: String!
 }

--- a/src/HotChocolate.Extensions.Translation/Configuration/RequestExecutorBuilderExtensions.cs
+++ b/src/HotChocolate.Extensions.Translation/Configuration/RequestExecutorBuilderExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class RequestExecutorBuilderExtensions
     {
-        private const string DefaultInterfaceName = "Translation";
+        private const string DefaultTranslationInterfaceName = "Translation";
         
         public static IRequestExecutorBuilder AddTranslation(
             this IRequestExecutorBuilder builder)
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             var translateDirective = new TranslateDirectiveType();
             var translationInterfaceType = new TranslationInterfaceType
-                { InterfaceName = DefaultInterfaceName };
+                { InterfaceName = DefaultTranslationInterfaceName };
 
             if (configure != null)
             {

--- a/src/HotChocolate.Extensions.Translation/Configuration/RequestExecutorBuilderExtensions.cs
+++ b/src/HotChocolate.Extensions.Translation/Configuration/RequestExecutorBuilderExtensions.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class RequestExecutorBuilderExtensions
     {
+        private const string DefaultInterfaceName = "Translation";
+        
         public static IRequestExecutorBuilder AddTranslation(
             this IRequestExecutorBuilder builder)
         {
@@ -18,7 +20,8 @@ namespace Microsoft.Extensions.DependencyInjection
             Action<TranslationBuilder>? configure)
         {
             var translateDirective = new TranslateDirectiveType();
-            var translationInterfaceType = new TranslationInterfaceType();
+            var translationInterfaceType = new TranslationInterfaceType
+                { InterfaceName = DefaultInterfaceName };
 
             if (configure != null)
             {


### PR DESCRIPTION
Set a more conventional name for `TranslationInterfaceType` during `AddTranslation`

Addresses #30
