### PR TITLE
Add ability to use data loader with string localizer

### DIFF
--- a/src/HotChocolate.Extensions.Translation/Resources/IFetcher.cs
+++ b/src/HotChocolate.Extensions.Translation/Resources/IFetcher.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace HotChocolate.Extensions.Translation.Resources
+{
+    public interface IFetcher
+    {
+        Task FetchAsync();
+    }
+}

--- a/src/HotChocolate.Extensions.Translation/TranslateDirectiveType.cs
+++ b/src/HotChocolate.Extensions.Translation/TranslateDirectiveType.cs
@@ -35,8 +35,8 @@ namespace HotChocolate.Extensions.Translation
             descriptor.Name(DirectiveName);
             descriptor.Location(DirectiveLocation.FieldDefinition);
 
-            descriptor.Use((next, directive) => context
-                => Translate(next, context, directive.AsValue<TranslateDirective<T>>()));
+            descriptor.Use((next, directive) => async context
+                => await Translate(next, context, directive.AsValue<TranslateDirective<T>>()));
         }
 
         private static async ValueTask Translate(
@@ -88,6 +88,11 @@ namespace HotChocolate.Extensions.Translation
             {
                 IStringLocalizer stringLocalizer =
                     localizerFactory.Create(directiveOptions.ResourceKeyPrefix, string.Empty);
+
+                if (stringLocalizer is IFetcher fetcher)
+                {
+                    await fetcher.FetchAsync();
+                }
 
                 IEnumerable<TranslationObserver>? observers =
                     context.Services.GetService<IEnumerable<TranslationObserver>>();  


### PR DESCRIPTION
The DataLoader does not work as expected due to it requires asynchronous invocation to be implemented.
A huck like GetAwaiter().GetResult() does not work.

